### PR TITLE
Do not try to back up extended attributes

### DIFF
--- a/manifests/rdiff_export.pp
+++ b/manifests/rdiff_export.pp
@@ -33,7 +33,7 @@ define rdiff_backup::rdiff_export (
     concat::fragment{ "backup_${cleanpath}":
       target  => $backup_script,
       #lint:ignore:80chars
-      content => "sleep $(( RANDOM %= ${cron_jitter} ))&&rdiff-backup ${path} ${remote_path}/${::fqdn}/${cleanpath}\n\n",
+      content => "sleep $(( RANDOM %= ${cron_jitter} ))&&rdiff-backup --no-eas ${path} ${remote_path}/${::fqdn}/${cleanpath}\n\n",
       #lint:endignore
       order   => '10'
     }
@@ -50,7 +50,7 @@ define rdiff_backup::rdiff_export (
     concat::fragment{ "backup_${cleanpath}":
       target  => $backup_script,
       #lint:ignore:80chars
-      content => "sleep $(( RANDOM %= ${cron_jitter} ))&&rdiff-backup ${path} ${rdiff_user}@${rdiff_server}::${remote_path}/${::fqdn}/${cleanpath}\n\n",
+      content => "sleep $(( RANDOM %= ${cron_jitter} ))&&rdiff-backup --no-eas ${path} ${rdiff_user}@${rdiff_server}::${remote_path}/${::fqdn}/${cleanpath}\n\n",
       #lint:endignore
       order   => '10'
     }


### PR DESCRIPTION
While it would be handy to be able to back up extended attributes, there
are too many problems that would result in trying to do so on an
rdiff-backup server running as unprivileged user -- especially under
SELinux enforcement. When performing a restore, the correct SELinux
attributes would be applied anyway during the write operation, or can be
fixed post-restore by running restorecon.

Passing --no-eas tells rdiff-backup not to try setting extended
attributes on files created on the remote backup server.

Signed-off-by: Konstantin Ryabitsev konstantin@linuxfoundation.org
